### PR TITLE
bug_fix:spell error

### DIFF
--- a/pastebin/example.py
+++ b/pastebin/example.py
@@ -21,7 +21,7 @@ else:
 	password = getpass.getpass('[?] - Password: ')
 	api_user_key = api.create_user_key(username, password)
 	if 'Bad API request' not in api_user_key:
-		print('[+] - You API user key is: ' + ap_user_key)
+		print('[+] - You API user key is: ' + api_user_key)
 		api = pastebin.PasteBin(api_dev_key, api_user_key)
 	else:
 		raise SystemExit('[!] - Failed to create API user key! ({0})'.format(api_user_key.split(', ')[1]))

--- a/pastebin/pastebin.py
+++ b/pastebin/pastebin.py
@@ -297,7 +297,7 @@ class PasteBin:
 
 	def create_user_key(self, username, password):
 		params = {'api_dev_key':self.api_dev_key, 'api_user_name':username, 'api_user_password':password}
-		return api_call('api_login.php', params)
+		return self.api_call('api_login.php', params)
 
 	def paste(self, data, guest=False, name=None, format=None, private=None, expire=None):
 		params = {'api_dev_key':self.api_dev_key, 'api_option':'paste', 'api_paste_code':data}


### PR DESCRIPTION
1.In example.py
`ap_user_key` should be `api_user_key`

2.In pastebin.py
there should be `return self.api_call(...)` instead of `return api_call(...)`